### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Dune (Jellyfin Android TV Client)
+
+Thank you for considering contributing to Dune! We welcome all contributions that help improve this project.
+
+## Code of Conduct
+
+This project adheres to the [Jellyfin Code of Conduct](https://github.com/jellyfin/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## How to Contribute
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally
+   ```
+   git clone https://github.com/your-username/DUNE.git
+   ```
+3. Create a new **feature branch** for your changes
+   ```
+   git checkout -b feature/your-feature-name
+   ```
+4. **Commit** your changes with a clear message
+   ```
+   git commit -m "Add your feature description"
+   ```
+5. **Push** to your fork
+   ```
+   git push origin feature/your-feature-name
+   ```
+6. Open a **Pull Request** against the `main` branch
+
+## Development Setup
+
+1. Open the project in Android Studio
+2. Ensure you have the latest Android SDK and build tools installed
+3. Sync the project with Gradle files
+4. Build and run the project
+
+## Code Style
+
+- Follow the official [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html)
+- Use 4 spaces for indentation
+- Keep lines under 120 characters
+- Write clear, concise commit messages
+- Document complex logic with comments
+
+## Reporting Issues
+
+When reporting bugs, please include:
+- Steps to reproduce the issue
+- Expected behavior
+- Actual behavior
+- Device/Android version information
+- Any relevant logs
+
+## Feature Requests
+
+For feature requests, please:
+1. Check if the feature already exists
+2. Explain why this feature would be valuable
+3. Provide any relevant design mockups or examples if applicable
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under the GPL-2.0 license.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,69 @@
+Dune - Jellyfin Android TV Client
+Copyright (C) 2023-2025 Sam42a
+
+This is a fork of Jellyfin for Android TV, which is free and open source software
+distributed under the terms of the GNU General Public License v2.0 (GPL-2.0).
+
+---
+
+Original Jellyfin Android TV:
+Copyright (C) 2017-2025 Jellyfin Contributors
+
+This product includes software developed by the Jellyfin Project (https://jellyfin.org/).
+Original source code and NOTICE file available at:
+https://github.com/jellyfin/jellyfin-androidtv
+
+---
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Third-party libraries used in this project:
+
+- Jellyfin SDK (GPL-2.0)
+  https://github.com/jellyfin/sdk-kotlin
+
+- AndroidX Libraries (Apache-2.0)
+  https://developer.android.com/jetpack/androidx
+
+- Kotlin Coroutines (Apache-2.0)
+  https://github.com/Kotlin/kotlinx.coroutines
+
+- Koin (Apache-2.0)
+  https://insert-koin.io/
+
+- Coil (Apache-2.0)
+  https://coil-kt.github.io/coil/
+
+- Markwon (Apache-2.0)
+  https://github.com/noties/Markwon
+
+- Timber (Apache-2.0)
+  https://github.com/JakeWharton/timber
+
+- ACRA (Apache-2.0)
+  https://github.com/ACRA/acra
+
+- Kotest (Apache-2.0)
+  https://kotest.io/
+
+- MockK (Apache-2.0)
+  https://mockk.io/
+
+- ExoPlayer (Apache-2.0)
+  https://exoplayer.dev/
+
+Full license texts are available in the respective library source code and in the
+app/src/main/assets/licenses directory.


### PR DESCRIPTION
"org.jellyfyn.androidtv.enhanced" becomes "org.jellyfin.androidtv.enhanced"