### PR TITLE
Fix backdrop display error in enhanced browse fragment

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/browsing/EnhancedBrowseFragment.java
@@ -179,6 +179,13 @@ public class EnhancedBrowseFragment extends Fragment implements RowLoader, View.
         }
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mClickedListener.removeListeners();
+        mSelectedListener.removeListeners();
+    }
+
     protected void setupQueries(RowLoader rowLoader) {
         rowLoader.loadRows(mRows);
     }


### PR DESCRIPTION
The Blackdrop always displayed incorrectly in the following cases:
- When we simply used the back button to return to the main menu.
- When we moved on to the element from the Recently added.

When EnhancedBrowseFragment destroyed, it affects the next Backdrop setting.