### PR TITLE
Let Exoplayer invalidate track selection on capabilities change again

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
+++ b/app/src/main/java/org/jellyfin/androidtv/ui/playback/VideoManager.java
@@ -223,6 +223,7 @@ public class VideoManager {
                         .setAudioOffloadMode(TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_ENABLED)
                         .build()
                 )
+                .setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true)
                 .build()
         );
         exoPlayerBuilder.setTrackSelector(trackSelector);


### PR DESCRIPTION
This re-applies the change from
95f8e4db22430060c818ca845916862b11bc3b12, which apparently was unexpectedly reverted with 3530e0a1fbb9c707854c9a9dd768733f47ed198d.

-----

Without this option, the Nvidia Shield could reproduce audio as PCM, instead of the expected passthrough, when matching the refresh rate.