### PR TITLE
Remove Content Limits for All Movies and All Collections Channels in LeanbackChannelWorker.kt

### DIFF
--- a/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
+++ b/app/src/main/java/org/jellyfin/androidtv/integration/LeanbackChannelWorker.kt
@@ -375,7 +375,6 @@ class LeanbackChannelWorker(
 				api.itemsApi.getItems(
 					includeItemTypes = listOf(BaseItemKind.MOVIE),
 					recursive = true,
-					limit = 50,
 					fields = ItemRepository.itemFields
 				).content.items
 			} catch (e: Exception) {
@@ -390,7 +389,6 @@ class LeanbackChannelWorker(
 				api.itemsApi.getItems(
 					includeItemTypes = listOf(BaseItemKind.BOX_SET),
 					recursive = true,
-					limit = 50,
 					fields = ItemRepository.itemFields
 				).content.items
 			} catch (e: Exception) {


### PR DESCRIPTION
The channel for **all shows** does not have a limit and as a result it displays the full library of shows available. The channels for **all movies** and **all movie collections** had content limits of 50 which results in only a portion of libraries being displayed.

This pull request removes the limits on movies and movie collections to be consistent with the all shows channel.

If this limit was an intentional change and has some rationale behind it, perhaps replacing the hard limits with a user configurable variable would be preferable. For example, the current limit of 50 could be a default, but users could set content limits of 100, 250, 500, 1000, etc. 